### PR TITLE
Mention BVG app rather than VBB app in README

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -4,7 +4,7 @@
 
 [![API status](https://badgen.net/uptime-robot/status/m784879513-ed3cc45a865db0ba57af0001)](https://stats.uptimerobot.com/57wNLs39M/784879513)
 
-Because it wraps [an API](https://github.com/public-transport/hafas-client/blob/master/readme.md#background) of BVG, it **includes all local traffic of Berlin & Brandenburg, as well as some long-distance trains running in the area**. Essentially, it returns whatever data the [VBB app](https://www.vbb.de/fahrplan/vbb-app) shows, **including realtime delays and disruptions**.
+Because it wraps [an API](https://github.com/public-transport/hafas-client/blob/master/readme.md#background) of BVG, it **includes all local traffic of Berlin & Brandenburg, as well as some long-distance trains running in the area**. Essentially, it returns whatever data the [BVG app](https://www.bvg.de/en/tickets-tariffs/all-apps/fahrinfo-app) shows, **including realtime delays and disruptions**.
 
 - [Getting Started](getting-started.md)
 - [API documentation](api.md)


### PR DESCRIPTION
## Description

I would think that the VBB app part of the README was simply copied from https://github.com/derhuerst/vbb-rest/blob/5/docs/readme.md previously and that this README should mention the BVG app instead.

However, I am actually not certain that this is actually accurate. @derhuerst you probably know, so feel free to correct this (or close it if the VBB link is actually correct).

Closes https://github.com/public-transport/transport.rest/issues/8 (note that it is super difficult to navigate all of the different repos; I already mentioned it in the issue on the other repo: there should be monorepos instead).

fixes https://github.com/public-transport/transport.rest/issues/8