### PR TITLE
docs: resolve 404 docker image link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@
 
 ### via Docker
 
-A Docker image [is available as `derhuerst/bvg-rest:6`](https://hub.docker.com/r/derhuerst/bvg-rest:6).
+A Docker image [is available as `derhuerst/bvg-rest:6`](https://hub.docker.com/r/derhuerst/bvg-rest).
 
 ```shell
 docker run -d -p 3000:3000 derhuerst/bvg-rest:6


### PR DESCRIPTION
Hi :wave:,

following the link to Docker Hub returns `HTTP/404`. I dediced to link to the overview as the direct link to the versioned image contains the digit in the URL.

Let me know if you want anything changed. 